### PR TITLE
Optional border added to png

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -138,11 +138,12 @@ class FileConverter:
         convert = plugin_settings.get("convert_binary", "convert"
                                       if sublime.platform() != 'windows' else
                                       'convert.exe')
+        border = plugin_settings.get("border", 0)
         directory, _ = os.path.split(file)
         os.chdir(directory)
         compile_cmd = [pdflatex, file]
         convert_cmd = [convert, '-density', '300', '-trim', '-quality', '100',
-                       pdf_name, png_name]
+                       '-border', str(border), pdf_name, png_name]
         foreground_color = plugin_settings.get('equation_foreground_color',
                                                'red')
         inline_size = plugin_settings.get('equation_inline_size', '100%')


### PR DESCRIPTION
When generating the png using convert, the trim is often too tight and things like block matrices are right at the edge and difficult to see.  Adding a border allows for a buffer to help viewing the previews.  This is a simple version of the fix to just show how it works and does not include an update of the settings file or a slightly more sophisticated logic that I used to have different borders for inline and block previews.